### PR TITLE
Use filters for order status in GoPay gateway

### DIFF
--- a/includes/class-gopay-gateway-api.php
+++ b/includes/class-gopay-gateway-api.php
@@ -410,9 +410,9 @@ class Gopay_Gateway_API {
 				}
 
 				if ( $all_virtual_downloadable ) {
-					$order->set_status( 'completed' );
+					$order->set_status( apply_filters( 'gopay_gateway_status_paid_virual_downloadable', 'completed', $order ) );
 				} else {
-					$order->set_status( 'processing' );
+					$order->set_status( apply_filters( 'gopay_gateway_status_paid', 'processing', $order ) );
 				}
 
 				// Update retry status.


### PR DESCRIPTION
Adding new filters "gopay_gateway_status_paid_virual_downloadable" and "gopay_gateway_status_paid" for possibility to set up final status on paid orders.

For automatization reasons, sometimes there is a need to set up status "completed" for paid orders. And because setting is called in template_redirect action, there is no way how to set up it.

Usage:
add_filter( 'gopay_gateway_status_paid', function($status, $order) { return 'completed'; }, 10, 2 );

Thank you and have a nice day, Petr Tomasek (tomy@tomy.cz).