### PR TITLE
Skip set_status('failed') when the order is already paid

### DIFF
--- a/includes/class-gopay-gateway-api.php
+++ b/includes/class-gopay-gateway-api.php
@@ -460,6 +460,19 @@ class Gopay_Gateway_API {
 			case 'CREATED':
 			case 'TIMEOUTED':
 			case 'CANCELED':
+				// Skip if the order has already been paid (e.g. customer switched
+				// payment method to a bank transfer after abandoning the card payment).
+				// Without this check, a late TIMEOUTED notification from GoPay would
+				// overwrite a paid order back to "failed".
+				if ( $order->is_paid() ) {
+					$order->add_order_note( sprintf(
+						/* translators: %s: GoPay payment state (e.g. TIMEOUTED). */
+						__( 'GoPay returned state "%s", but the order is already paid - status change skipped.', 'gopay-gateway' ),
+						$response->json['state']
+					) );
+					wp_safe_redirect( $order->get_checkout_order_received_url() );
+					exit;
+				}
 				$order->set_status( 'failed' );
 				$order->save();
 				wp_safe_redirect( $order->get_checkout_order_received_url() );


### PR DESCRIPTION
## Problem

When a customer abandons a card payment via GoPay and later pays the **same** order through a **different** method (typically a BACS bank transfer against a proforma invoice), the original GoPay transaction stays open on GoPay's side. Roughly one hour later, GoPay reports that transaction back to the shop as `state=TIMEOUTED`.

`Gopay_Gateway_API::check_payment_status()` then locates the order via the `GoPay_Transaction_id` meta and runs:

```php
case 'CREATED':
case 'TIMEOUTED':
case 'CANCELED':
    $order->set_status( 'failed' );
    $order->save();
```

— without checking the current state of the order. As a result an order that is already **paid and in `processing`** gets overwritten to **`failed`**, with no obvious cause visible to the merchant.

This is the same kind of late-notification race that was addressed for the `PAID` branch in 1.0.26 (`is_paid()` early-return). This PR applies the symmetric guard to the negative branches.

## Real-world reproduction

Observed on a production WooCommerce shop running gopay-woocommerce **1.0.25**. Code path is unchanged in **1.0.28**, so the bug still reproduces on `development`.

Order timeline (CEST = UTC+2):

| Time | Event |
|------|-------|
| 15:40 | Customer chooses card payment — `wp_gopay_gateway_log: Payment created`, tx_id `9253140964` |
| 15:45 | Customer abandons card payment, switches to BACS proforma. `payment_method` becomes `bacs`, but `GoPay_Transaction_id` meta stays on the order. |
| 16:10 | Customer pays the proforma. Fakturoid webhook (`wpify-woo-fakturoid`) sets the order to `processing`. |
| **16:41** | **GoPay calls the shop with `state=TIMEOUTED` for tx `9253140964`** (1 h 1 min after \`Payment created\`). `check_payment_status()` finds the order via the meta and calls \`set_status('failed')\` on the already-paid order. |

GoPay API response captured in \`wp_gopay_gateway_log.id=86372\`:

\`\`\`json
{
  \"id\": 9253140964,
  \"order_number\": \"66197\",
  \"state\": \"TIMEOUTED\",
  ...
}
\`\`\`

## Fix

Add an \`is_paid()\` short-circuit at the top of the \`CREATED / TIMEOUTED / CANCELED\` branch (same shape as the existing guard in the \`PAID\` branch), plus an order note so the merchant can see what happened.

\`\`\`php
case 'CREATED':
case 'TIMEOUTED':
case 'CANCELED':
    if ( \$order->is_paid() ) {
        \$order->add_order_note( sprintf(
            __( 'GoPay returned state \"%s\", but the order is already paid - status change skipped.', 'gopay-gateway' ),
            \$response->json['state']
        ) );
        wp_safe_redirect( \$order->get_checkout_order_received_url() );
        exit;
    }
    \$order->set_status( 'failed' );
    ...
\`\`\`

## Notes

- The diff is intentionally minimal — just the \`is_paid()\` guard. Other open issues (e.g. #10 about missing \`exit;\` calls on later branches) are out of scope here.
- No new strings outside the order note; existing translation domain reused.
- Tested manually against the upstream \`development\` branch; \`php -l\` passes.